### PR TITLE
Update eventful.gemspec

### DIFF
--- a/eventful.gemspec
+++ b/eventful.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files = %w[README.rdoc History.txt] + Dir.glob("{lib,spec}/**/*.rb")
 
-  s.add_dependency "methodphitamine", "= 1.0.2"
+  s.add_dependency "methodphitamine", "= 1.0.1"
   s.add_development_dependency "rspec"
 end
 

--- a/eventful.gemspec
+++ b/eventful.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = "eventful"
-  s.version           = "1.0.1"
+  s.version           = "1.0.2"
   s.summary           = "A little pub/sub abstraction based on Observable"
   s.author            = "James Coglan"
   s.email             = "jcoglan@gmail.com"
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files = %w[README.rdoc History.txt] + Dir.glob("{lib,spec}/**/*.rb")
 
-  s.add_dependency "methodphitamine", "= 1.0.0"
+  s.add_dependency "methodphitamine", "= 1.0.2"
   s.add_development_dependency "rspec"
 end
 


### PR DESCRIPTION
bump methodphitamine version to remove "warning: undefining `object_id' may cause serious problem" messages